### PR TITLE
feat: add dev tooling link

### DIFF
--- a/utils/ecosystem.ts
+++ b/utils/ecosystem.ts
@@ -142,7 +142,7 @@ export const cards = [
     title: "Dev Tooling",
     description: "Discover our rich ecosystem for developer",
     isComingSoon: false,
-    link: "wip-link", // TODO(@consvic): add link
+    link: "https://docs.sophon.xyz/sophon/build/partners/overview",
     icon: "/img/home/docs.svg",
   },
   {


### PR DESCRIPTION
Add Dev Tooling link in ecosystem page: docs.sophon.xyz/build/partners/overview