### PR TITLE
feat: re-estimate fees on network change

### DIFF
--- a/components/common/input/TransactionAmount.vue
+++ b/components/common/input/TransactionAmount.vue
@@ -139,6 +139,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  isCorrectNetwork: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const emit = defineEmits<{
@@ -219,6 +223,7 @@ const setMaxAmount = () => {
 
 const amountError = computed(() => {
   if (!selectedToken.value) return;
+  if (!props.isCorrectNetwork) return;
   if (tokenBalance.value && totalComputeAmount.value.gt(tokenBalance.value.amount)) {
     return "exceeds_balance";
   }

--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -18,10 +18,12 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
   const { getL1VoidSigner } = useZkSyncWalletStore();
   const { requestProvider } = useZkSyncProviderStore();
   const onboardStore = useOnboardStore();
+  const { account } = storeToRefs(onboardStore);
 
   let params = {
     to: undefined as string | undefined,
     tokenAddress: undefined as string | undefined,
+    accountChainId: undefined as number | undefined,
   };
 
   const fee = ref<DepositFeeValues | undefined>();
@@ -133,6 +135,7 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
       params = {
         to,
         tokenAddress,
+        accountChainId: account.value.chainId,
       };
       await cacheEstimateFee(params);
     },

--- a/views/transactions/Deposit.vue
+++ b/views/transactions/Deposit.vue
@@ -58,6 +58,7 @@
           :max-amount="maxAmount"
           :approve-required="!enoughAllowance && (!tokenCustomBridge || !tokenCustomBridge.bridgingDisabled)"
           :loading="tokensRequestInProgress || balanceInProgress"
+          :is-correct-network="account.chainId === l1Network?.id"
           class="mb-block-padding-1/2 sm:mb-block-gap"
           @additional-token-found="handleAdditionalToken"
         >

--- a/views/transactions/Deposit.vue
+++ b/views/transactions/Deposit.vue
@@ -655,6 +655,17 @@ watch(
   }
 );
 
+// Add a watcher to re-estimate fees when account's chainId changes
+watch(
+  () => account.value.chainId,
+  async (newChainId, oldChainId) => {
+    if (newChainId !== oldChainId) {
+      await resetFee();
+      await estimate();
+    }
+  }
+);
+
 const autoUpdatingFee = computed(() => !feeError.value && fee.value && !feeLoading.value);
 const { reset: resetAutoUpdateEstimate, stop: stopAutoUpdateEstimate } = useInterval(async () => {
   if (!autoUpdatingFee.value) return;


### PR DESCRIPTION
- Add a `watch` to re-estimate fees on account's chainId changes
- Add a `accountChainId` to estimate fee params so we don't use cached values and always re-estimate on network change