### PR TITLE
feat: add eth and stable coins token price

### DIFF
--- a/composables/useEthPrice.ts
+++ b/composables/useEthPrice.ts
@@ -1,0 +1,26 @@
+import { $fetch } from "ofetch";
+
+export default () => {
+  const {
+    inProgress: fetchEthPriceInProgress,
+    error: fetchEthPriceError,
+    execute: requestEthPrice,
+    reset: resetFetchEthPrice,
+  } = usePromise<number>(async () => {
+    const response = await $fetch("https://block-explorer-api.mainnet.zksync.io/api?module=stats&action=ethprice");
+    const ethPrice = +response.result.ethusd;
+    return ethPrice;
+  });
+
+  const fetchEthPrice = async () => {
+    resetFetchEthPrice();
+    const ethPrice = await requestEthPrice();
+    return ethPrice;
+  };
+
+  return {
+    fetchEthPrice,
+    fetchEthPriceInProgress,
+    fetchEthPriceError,
+  };
+};

--- a/hyperchains/config.json
+++ b/hyperchains/config.json
@@ -51,14 +51,16 @@
         "l1Address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         "symbol": "USDT",
         "decimals": 6,
-        "iconUrl": "/img/usdt.svg"
+        "iconUrl": "/img/usdt.svg",
+        "price": 1
       },
       {
         "address": "0x9Aa0F72392B5784Ad86c6f3E899bCc053D00Db4F",
         "l1Address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "symbol": "USDC",
         "decimals": 6,
-        "iconUrl": "/img/usdc.svg"
+        "iconUrl": "/img/usdc.svg",
+        "price": 1
       },
       {
         "address": "0xA96aD8EC6A83F23e0A75E5d8c9cE13C1042c4295",

--- a/store/zksync/ethereumBalance.ts
+++ b/store/zksync/ethereumBalance.ts
@@ -18,7 +18,7 @@ export const useZkSyncEthereumBalanceStore = defineStore("zkSyncEthereumBalances
   const { balance: ethereumBalance } = storeToRefs(ethereumBalancesStore);
   const { l1Tokens } = storeToRefs(tokensStore);
   const additionalTokenAddresses = useStorage<string[]>("additionalTokenAddresses", []);
-
+  const { fetchEthPrice } = useEthPrice();
   const getBalancesFromApi = async (): Promise<TokenAmount[]> => {
     await Promise.all([ethereumBalancesStore.requestBalance(), tokensStore.requestTokens()]);
 
@@ -92,11 +92,14 @@ export const useZkSyncEthereumBalanceStore = defineStore("zkSyncEthereumBalances
             throw new Error(`Balance for token ${token.symbol} is undefined`);
           }
 
+          const price = token.address === utils.ETH_ADDRESS ? await fetchEthPrice() : token.price;
+
           return {
             ...token,
             symbol: token.symbol ?? balance.symbol,
             decimals: token.decimals ?? balance.decimals,
             amount: balance.value.toString(),
+            price,
           };
         } catch (error) {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
Currently we are not getting ETH token price which can result in bad UX, since we are not displaying USD price for fee and token balance.

- Add ETH token price from ZKSync block explorer API;
- Temporary USDC and USDT hardcoded $1 price