### PR TITLE
fix: use L1 mainnet always for resolving ens

### DIFF
--- a/composables/useEnsName.ts
+++ b/composables/useEnsName.ts
@@ -1,10 +1,10 @@
 import { useMemoize } from "@vueuse/core";
 import { getEnsAddress } from "@wagmi/core";
 
-import { wagmiConfig } from "@/data/wagmi";
+import { wagmiL1Config } from "@/data/wagmi";
 
 export default (ensName: Ref<string>) => {
-  const fetchEnsAddress = useMemoize((name: string) => getEnsAddress(wagmiConfig, { name, chainId: 1 }));
+  const fetchEnsAddress = useMemoize((name: string) => getEnsAddress(wagmiL1Config, { name, chainId: 1 }));
 
   const nameToAddress = ref<{ [name: string]: string }>({});
   const {

--- a/data/wagmi.ts
+++ b/data/wagmi.ts
@@ -2,7 +2,7 @@ import { fallback, http } from "@wagmi/core";
 import { zkSync, type Chain, zkSyncSepoliaTestnet, zkSyncTestnet } from "@wagmi/core/chains";
 import { defaultWagmiConfig } from "@web3modal/wagmi";
 
-import { chainList, type ZkSyncNetwork } from "@/data/networks";
+import { chainList, l1Networks, type ZkSyncNetwork } from "@/data/networks";
 
 const portalRuntimeConfig = usePortalRuntimeConfig();
 
@@ -49,6 +49,7 @@ const getAllChains = () => {
       chains.push(chain);
     }
   };
+
   for (const network of chainList) {
     addUniqueChain(useExistingEraChain(network) ?? formatZkSyncChain(network));
     if (network.l1Network) {
@@ -65,6 +66,16 @@ export const wagmiConfig = defaultWagmiConfig({
   transports: Object.fromEntries(
     chains.map((chain) => [chain.id, fallback(chain.rpcUrls.default.http.map((e) => http(e)))])
   ),
+  projectId: portalRuntimeConfig.walletConnectProjectId,
+  metadata,
+  enableCoinbase: false,
+});
+
+export const wagmiL1Config = defaultWagmiConfig({
+  chains: [l1Networks.mainnet],
+  transports: Object.fromEntries([
+    [l1Networks.mainnet.id, fallback(l1Networks.mainnet.rpcUrls.default.http.map((e) => http(e)))],
+  ]),
   projectId: portalRuntimeConfig.walletConnectProjectId,
   metadata,
   enableCoinbase: false,


### PR DESCRIPTION
## Changes
- Force only L1 provider for ens resolution

<img width="857" alt="image" src="https://github.com/user-attachments/assets/49e1f1ae-96e4-4e0e-8995-d326c41f703e" />
