### PR TITLE
fix: only display the add token to wallet button if the flow is for sophon network

### DIFF
--- a/components/token/TokenBalance.vue
+++ b/components/token/TokenBalance.vue
@@ -15,6 +15,7 @@
         <template #secondary>
           <div class="flex items-center gap-3">
             <CommonButtonAddToWalletButton
+              v-if="shouldShowAddToWallet"
               :asset="{
               address: address as `0x${string}`,
               decimals,
@@ -44,6 +45,8 @@ import { BigNumber } from "ethers";
 
 import type { TokenPrice } from "@/types";
 import type { BigNumberish } from "ethers";
+
+const route = useRoute();
 
 const props = defineProps({
   as: {
@@ -82,6 +85,8 @@ const props = defineProps({
     type: String,
   },
 });
+
+const shouldShowAddToWallet = computed(() => route.path !== "/bridge");
 
 const isZeroAmount = computed(() => BigNumber.from(props.amount).isZero());
 


### PR DESCRIPTION
## Changes
- Meaning, dont display add to wallet if it's L1