### PR TITLE
fix: skip approve check in L1 if token is lz

### DIFF
--- a/views/transactions/Deposit.vue
+++ b/views/transactions/Deposit.vue
@@ -520,6 +520,9 @@ const enoughAllowance = computed(() => {
   if (!allowance.value || !selectedToken.value) {
     return true;
   }
+  if (selectedToken.value.isOft) {
+    return true;
+  }
   return !allowance.value.isZero() && allowance.value.gte(totalComputeAmount.value);
 });
 const setAmountToCurrentAllowance = () => {


### PR DESCRIPTION
## Changes
- LayerZero OFTs don't need to be approved to be bridged