### PR TITLE
Feat - three hour wait msg update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tests/e2e/reports
 tests/e2e/artifacts
 allure-results
 .env.local
+.env

--- a/components/transaction/TransactionProgress.vue
+++ b/components/transaction/TransactionProgress.vue
@@ -91,7 +91,12 @@
         v-if="expectedCompleteTimestamp && !token.isOft && !completed"
         class="flex flex-col items-center justify-center gap-[2px]"
       >
-        <div>
+        <div v-if="transactionInfo.type === 'withdrawal' && !token.isOft">
+          <span class="text-gray"
+            >Withdrawals are usually processed in 3 hours, but can take longer in some occasions.</span
+          >
+        </div>
+        <div v-else>
           <span class="text-gray">Processing time: </span>
           <CommonTimer format="human-readable" :future-date="expectedCompleteTimestamp">
             <template #default="{ timer, isTimerFinished }">

--- a/utils/doc-links.ts
+++ b/utils/doc-links.ts
@@ -1,3 +1,3 @@
 export const TOKEN_ALLOWANCE = "https://cryptotesters.com/blog/token-allowances";
 
-export const ZKSYNC_WITHDRAWAL_DELAY = "https://docs.zksync.io/build/support/withdrawal-delay.html#withdrawal-delay";
+export const ZKSYNC_WITHDRAWAL_DELAY = "https://docs.sophon.xyz/discover/bridging/withdrawal-delay";

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -128,19 +128,14 @@
       </template>
       <template v-else-if="step === 'withdrawal-finalization-warning'">
         <CommonAlert variant="warning" :icon="ExclamationTriangleIcon" class="mb-block-padding-1/2 sm:mb-block-gap">
-          <p v-if="!isCustomNode">
-            After a
-            <a class="underline underline-offset-2" :href="ZKSYNC_WITHDRAWAL_DELAY" target="_blank"
-              >24-hour withdrawal delay</a
-            >, you will need to manually claim your funds which requires paying another transaction fee on
+          <p>
+            After the withdraw is processed and finalized (which takes
+            <a class="underline underline-offset-2" :href="ZKSYNC_WITHDRAWAL_DELAY" target="_blank">3 or more hours</a
+            >), you will need to manually claim your funds which requires paying another transaction fee on
             {{ eraNetwork.l1Network?.name }}. Alternatively you can use
             <a href="https://layerswap.io/app" target="_blank" class="underline underline-offset-2"
               >third-party bridges</a
             >.
-          </p>
-          <p v-else>
-            After transaction is executed on {{ eraNetwork.l1Network?.name }}, you will need to manually claim your
-            funds which requires paying another transaction fee on {{ eraNetwork.l1Network?.name }}.
           </p>
         </CommonAlert>
         <CommonButton size="lg" variant="primary" class="mx-auto mt-block-gap w-full" @click="buttonContinue()">
@@ -149,17 +144,17 @@
       </template>
       <template v-else-if="step === 'confirm'">
         <CommonAlert
-          v-if="type === 'withdrawal' && !isCustomNode"
+          v-if="type === 'withdrawal'"
           variant="warning"
           :icon="ExclamationTriangleIcon"
           class="mb-block-padding-1/2 sm:mb-block-gap"
         >
           <p v-if="withdrawalManualFinalizationRequired">
-            You will be able to claim your withdrawal only after a 24-hour withdrawal delay.
+            You will be able to claim your withdrawal only after it is finalized (which takes 3 or more hours).
             <a class="underline underline-offset-2" :href="ZKSYNC_WITHDRAWAL_DELAY" target="_blank">Learn more</a>
           </p>
           <p v-else>
-            You will receive funds only after a 24-hour withdrawal delay.
+            You will receive your funds once withdraw is finalized, which takes 3 or more hours.
             <a class="underline underline-offset-2" :href="ZKSYNC_WITHDRAWAL_DELAY" target="_blank">Learn more</a>
           </p>
         </CommonAlert>
@@ -210,13 +205,13 @@
             />
           </transition>
           <CommonButtonLabel
-            v-if="type === 'withdrawal' && !isCustomNode"
+            v-if="type === 'withdrawal' && !selectedToken?.isOft"
             as="a"
             :href="ZKSYNC_WITHDRAWAL_DELAY"
             target="_blank"
             class="ml-auto text-right"
           >
-            Up to 24 hours
+            3 or more hours to be finalized
           </CommonButtonLabel>
           <CommonButtonLabel v-else-if="type === 'transfer'" as="span" class="ml-auto text-right">
             Almost instant
@@ -341,7 +336,7 @@ import useLayerzeroTransaction from "@/composables/layerzero/useTransaction";
 import useFee from "@/composables/zksync/useFee";
 import useTransaction, { isWithdrawalManualFinalizationRequired } from "@/composables/zksync/useTransaction";
 import { customBridgeTokens } from "@/data/customBridgeTokens";
-import { isCustomNode, isMainnet } from "@/data/networks";
+import { isMainnet } from "@/data/networks";
 import TransferSubmitted from "@/views/transactions/TransferSubmitted.vue";
 import WithdrawalSubmitted from "@/views/transactions/WithdrawalSubmitted.vue";
 import useWithdrawalAllowance from "~/composables/transaction/useWithdrawalAllowance";

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -144,17 +144,13 @@
       </template>
       <template v-else-if="step === 'confirm'">
         <CommonAlert
-          v-if="type === 'withdrawal'"
+          v-if="type === 'withdrawal' && withdrawalManualFinalizationRequired"
           variant="warning"
           :icon="ExclamationTriangleIcon"
           class="mb-block-padding-1/2 sm:mb-block-gap"
         >
-          <p v-if="withdrawalManualFinalizationRequired">
+          <p>
             You will be able to claim your withdrawal only after it is finalized (which takes 3 or more hours).
-            <a class="underline underline-offset-2" :href="ZKSYNC_WITHDRAWAL_DELAY" target="_blank">Learn more</a>
-          </p>
-          <p v-else>
-            You will receive your funds once withdraw is finalized, which takes 3 or more hours.
             <a class="underline underline-offset-2" :href="ZKSYNC_WITHDRAWAL_DELAY" target="_blank">Learn more</a>
           </p>
         </CommonAlert>

--- a/views/transactions/WithdrawalSubmitted.vue
+++ b/views/transactions/WithdrawalSubmitted.vue
@@ -9,7 +9,7 @@
           Your funds will be available on <span class="font-medium">{{ transaction.to.destination.label }}</span> after
           you claim the withdrawal.
         </template>
-        <template v-else-if="isCustomNode && !canSkipClaim">
+        <template v-else-if="!canSkipClaim">
           Your funds will be available for claiming after the transaction is processed on
           <span class="font-medium">{{ eraNetwork.name }}</span> and executed on the
           <span class="font-medium">{{ eraNetwork.l1Network?.name }}</span
@@ -111,7 +111,7 @@
         <TransactionFeeDetails
           v-else
           label="Claiming fee:"
-          :fee-token="feeToken"
+          :fee-token="feeToken.value"
           :fee-amount="fee"
           :loading="feeLoading"
           class="mt-4"
@@ -171,7 +171,6 @@
 import { ExclamationTriangleIcon } from "@heroicons/vue/24/outline";
 
 import useWithdrawalFinalization from "@/composables/zksync/useWithdrawalFinalization";
-import { isCustomNode } from "@/data/networks";
 import { MAINNET } from "~/data/mainnet";
 import { TESTNET } from "~/data/testnet";
 


### PR DESCRIPTION
## Changes
- Disabled custom node check for some messages
- Changed withdrawal delay period messaging to be 3 hours instead of 24