### PR TITLE
fix: update L1 gas limit

### DIFF
--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -71,7 +71,7 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
   };
   const getERC20TransactionFee = () => {
     return {
-      l1GasLimit: BigNumber.from(utils.L1_RECOMMENDED_MIN_ERC20_DEPOSIT_GAS_LIMIT),
+      l1GasLimit: BigNumber.from(1000000), // TODO: replace for zksync-ethers value when we have updated the package
     };
   };
   const getGasPrice = async () => {


### PR DESCRIPTION
We are having issues related to l1GasLimit in Portal. As a fix we should increase the hardcoded amount as we still didn't updated the project to the latest zksync-ethers version

Before increase: 400_000
After: 1_000_000