### PR TITLE
[SOP-760] fix: oft transfer confirmation ui

### DIFF
--- a/components/transaction/TransactionProgress.vue
+++ b/components/transaction/TransactionProgress.vue
@@ -205,7 +205,7 @@ const {
   status: lzStatus,
   error: lzError,
   destinationTxHash,
-} = useLayerZeroTransactionStatus(computed(() => props.transactionInfo));
+} = useLayerZeroTransactionStatus(computed(() => props.transactionInfo || {}));
 
 const transactionProgressAnimationState = computed<AnimationState>(() => {
   if (props.animationState) return props.animationState;

--- a/composables/layerzero/useTransactionStatus.ts
+++ b/composables/layerzero/useTransactionStatus.ts
@@ -116,7 +116,7 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
   };
 
   // Start checking status when the composable is created
-  if (transactionInfo.value.token.isOft) {
+  if (transactionInfo.value && transactionInfo.value.token?.isOft) {
     checkTransactionStatus();
   }
 

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -612,7 +612,7 @@ const estimate = async () => {
   ) {
     return;
   }
-  if (transaction.value?.token.isOft && props.type === "withdrawal") {
+  if (transaction.value?.token.isOft) {
     await estimateLayerzeroFee(
       {
         type: props.type,

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -509,8 +509,12 @@ const {
   estimateFee: estimateLayerzeroFee,
 } = useLayerzeroFee(walletStore.getSigner, providerStore.requestProvider);
 
-const gasLimit = computed(() => (selectedToken.value?.isOft ? gasLimitLayerzero.value : gasLimitDefault.value));
-const gasPrice = computed(() => (selectedToken.value?.isOft ? gasPriceLayerzero.value : gasPriceDefault.value));
+const gasLimit = computed(() =>
+  selectedToken.value?.isOft && props.type === "withdrawal" ? gasLimitLayerzero.value : gasLimitDefault.value
+);
+const gasPrice = computed(() =>
+  selectedToken.value?.isOft && props.type === "withdrawal" ? gasPriceLayerzero.value : gasPriceDefault.value
+);
 
 const queryAddress = useRouteQuery<string | undefined>("address", undefined, {
   transform: String,
@@ -612,7 +616,7 @@ const estimate = async () => {
   ) {
     return;
   }
-  if (transaction.value?.token.isOft) {
+  if (transaction.value?.token.isOft && props.type === "withdrawal") {
     await estimateLayerzeroFee(
       {
         type: props.type,


### PR DESCRIPTION
- Enable fee estimation for OFT transfer, not only withdrawal
- Add null checks to make sure transactionInfo.value and transactionInfo.value.token are defined before accessing isOft.
- Add a fallback of an empty object when passing props.transactionInfo to ensure the composable always receives some data.
