### PR TITLE
[SOP-919] feat: reclaim when tx status is failed

### DIFF
--- a/store/zksync/withdrawals.ts
+++ b/store/zksync/withdrawals.ts
@@ -34,12 +34,16 @@ export const useZkSyncWithdrawalsStore = defineStore("zkSyncWithdrawals", () => 
       );
 
       const withdrawalFinalizationAvailable = !!transactionDetails.ethExecuteTxHash;
-      const isFinalized = withdrawalFinalizationAvailable
+      let isFinalized = withdrawalFinalizationAvailable
         ? await useZkSyncWalletStore()
             .getL1VoidSigner(true)
             ?.isWithdrawalFinalized(withdrawal.transactionHash)
             .catch(() => false)
         : false;
+
+      if (withdrawalFinalizationAvailable && transactionDetails.status === "failed") {
+        isFinalized = false; // Allow claiming again if status is failed
+      }
 
       transactionStatusStore.saveTransaction({
         type: "withdrawal",


### PR DESCRIPTION
it seems we weren't  properly checking if the transaction attempt was successful or failed. The isWithdrawalFinalized method was returning true even though the transaction didn't complete successfully. So we need to explicitly check the transaction status, so if it's failed we allow the user to try again.