### PR TITLE
fix: enhance token balance fetching with pagination support

### DIFF
--- a/store/ethereumBalance.ts
+++ b/store/ethereumBalance.ts
@@ -48,6 +48,19 @@ export const useEthereumBalanceStore = defineStore("ethereumBalance", () => {
         alchemy.core.getBalance(account.value.address),
       ]);
 
+      let pageKey = tokenBalances.pageKey;
+
+      // Loop up to 2 more times to fetch subsequent pages if a pageKey exists
+      for (let i = 0; i < 2 && pageKey; i++) {
+        // Add a small delay to avoid rate limiting
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        const nextTokenBalances = await alchemy.core.getTokensForOwner(account.value.address, {
+          pageKey,
+        });
+        tokenBalances.tokens.push(...nextTokenBalances.tokens);
+        pageKey = nextTokenBalances.pageKey;
+      }
+
       const tokens: TokenAmount[] = tokenBalances.tokens
         .filter((token) => BigInt(token.rawBalance || "0") > 0n)
         .map((token) => ({


### PR DESCRIPTION
## Changes
- If a user has lots of balances and/or has had balance on multiple tokens we won't be able to fetch all their tokens in one go since alchemy limits are to 100 tokens. Added 2 more pages to fetch more tokens so up to 300 tokens. 
Still TBD if that's enough but should be good enough for now otherwise we might get rate limited by alchemy