### PR TITLE
[SOP-1632] feat: disable withdrawals on testnet

### DIFF
--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -45,6 +45,14 @@
 
     <form v-else @submit.prevent="">
       <template v-if="step === 'form'">
+        <CommonAlert
+          v-if="!isMainnet(eraNetwork.id) && props.type === 'withdrawal'"
+          variant="error"
+          :icon="ExclamationTriangleIcon"
+          class="mb-4"
+        >
+          <p>Withdrawals are currently not available on Sophon testnet.</p>
+        </CommonAlert>
         <TransactionWithdrawalsAvailableForClaimAlert />
         <CommonInputTransactionAmount
           v-model="amount"
@@ -334,6 +342,7 @@ import { customBridgeTokens } from "@/data/customBridgeTokens";
 import TransferSubmitted from "@/views/transactions/TransferSubmitted.vue";
 import WithdrawalSubmitted from "@/views/transactions/WithdrawalSubmitted.vue";
 import useWithdrawalAllowance from "~/composables/transaction/useWithdrawalAllowance";
+import { isMainnet } from "~/data/networks";
 
 import type { FeeEstimationParams } from "@/composables/zksync/useFee";
 import type { Token, TokenAmount } from "@/types";
@@ -673,7 +682,8 @@ const continueButtonDisabled = computed(() => {
     !enoughBalanceToCoverFee.value ||
     !enoughBalanceForTransaction.value ||
     !!amountError.value ||
-    BigInt(transaction.value.token.amount) === 0n
+    BigInt(transaction.value.token.amount) === 0n ||
+    (!isMainnet(eraNetwork.value.id) && props.type === "withdrawal") // disable withdrawal on testnet
   ) {
     return true;
   }


### PR DESCRIPTION
Due to recent testnet issues, we need to disable withdrawals so users don't lose their tokens when initializing a withdrawal.
- Disabled "Continue" button when on tesnet and transaction type is "withdrawal"
- Added a banner for making clear to users that withdrawals are currently disabled

<img width="865" height="496" alt="Screenshot 2025-09-22 at 15 28 57" src="https://github.com/user-attachments/assets/f8f2a501-1f9d-4495-8f36-20c70f8d3222" />
